### PR TITLE
remove automatically added suffixes from counter metric names

### DIFF
--- a/recorder/meter.go
+++ b/recorder/meter.go
@@ -31,6 +31,10 @@ func NewMeter(c MeterConfig) otelmetric.Meter {
 	var err error
 
 	var opt []exporter.Option
+	{
+		opt = append(opt, exporter.WithoutCounterSuffixes())
+	}
+
 	if c.Reg != nil {
 		opt = append(opt, exporter.WithRegisterer(c.Reg))
 	}


### PR DESCRIPTION
The recent update has surfaced a behaviour change in the construction of metric names. E.g. we are working with counters like this one.

```
worker_handler_execution_total
```

The OTEL libs started to append the `_total` suffix to counters automatically, which in my mind forces us to hide the structure of the metric names as they are defined in our code. So I don't know who thought it was a good idea to blindly append the suffix if it already conforms to the standard, but the problem we see right now is that our metrics would end up like this.

```
worker_handler_execution_total_total
```

The fix for us is to simply turn of this "feature".